### PR TITLE
qt6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,17 @@ name: Release Builds
 on: push
 
 env:
-  QT5_VERSION: 'v5.15.2'
+  QT5_VERSION: 'v6.1.0'
 
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
+    # bumped ubuntu version to get libxcb>=1.13 https://bugreports.qt.io/browse/QTBUG-85989
     env:
       INSTALL_PREFIX: '/opt/smelibs'
       SUDO_CMD: 'sudo'
-      CONFIGURE_EXTRAS: '-xcb -bundled-xcb-xinput'
+      CONFIGURE_EXTRAS: '-DFEATURE_xcb=ON -DINPUT_bundled_xcb_xinput=yes -DFEATURE_libudev=OFF'
       OS: 'linux'
     defaults:
       run:
@@ -21,7 +22,7 @@ jobs:
     - name: Install Qt build dependencies
       run: |
         sudo apt update -yy
-        sudo apt install -yy libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxkbcommon-dev libxkbcommon-x11-dev libxcb-xinerama0-dev libxcb-util-dev
+        sudo apt install -yy libglu1-mesa-dev ninja-build libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxkbcommon-dev libxkbcommon-x11-dev '^libxcb.*-dev'
     - name: Set gcc version
       run: |
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100
@@ -40,12 +41,14 @@ jobs:
       INSTALL_PREFIX: '/opt/smelibs'
       SUDO_CMD: 'sudo'
       MACOSX_DEPLOYMENT_TARGET: '10.14'
-      CONFIGURE_EXTRAS: '-bundled-xcb-xinput'
+      CONFIGURE_EXTRAS: ''
       OS: 'osx'
     defaults:
       run:
         shell: bash
     steps:
+      - name: Brew install ninja
+        run: brew install ninja
       - uses: actions/checkout@v2
       - name: Build script
         run: ./build.sh
@@ -59,7 +62,7 @@ jobs:
     env:
       INSTALL_PREFIX: '/c/smelibs'
       SUDO_CMD: ''
-      CONFIGURE_EXTRAS: '-platform win32-g++ -static-runtime -no-zstd'
+      CONFIGURE_EXTRAS: '-DQT_QMAKE_TARGET_MKSPEC=win32-g++'
       OS: 'win64'
     defaults:
       run:
@@ -70,7 +73,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: mingw-w64-x86_64-gcc make git
+          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja git
       - name: Build script
         run: ./build.sh
       - uses: actions/upload-artifact@v2
@@ -83,7 +86,7 @@ jobs:
     env:
       INSTALL_PREFIX: '/c/smelibs'
       SUDO_CMD: ''
-      CONFIGURE_EXTRAS: '-platform win32-g++ -static-runtime -no-zstd'
+      CONFIGURE_EXTRAS: '-DQT_QMAKE_TARGET_MKSPEC=win32-g++'
       OS: 'win32'
     defaults:
       run:
@@ -94,7 +97,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: mingw-w64-i686-gcc make git
+          install: mingw-w64-i686-gcc mingw-w64-i686-cmake mingw-w64-i686-ninja git
       - name: Build script
         run: ./build.sh
       - uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # sme_deps_qt5 [![Release Builds](https://github.com/spatial-model-editor/sme_deps_qt5/actions/workflows/release.yml/badge.svg)](https://github.com/spatial-model-editor/sme_deps_qt5/actions/workflows/release.yml)
 
-A minimal static build of Qt5:
+A minimal static build of Qt6:
 
-- Qt version: [Qt 5.15.2](https://doc.qt.io/qt-5/)
-- Qt license: [LGPLv3](https://doc.qt.io/qt-5/lgpl.html)
+- Qt version: [Qt 6.1.0](https://doc.qt.io/qt-6/)
+- Qt license: [LGPLv3](https://doc.qt.io/qt-6/lgpl.html)
 
 Get the latest versions here:
 
-- linux (gcc 9 / Ubuntu 16.04): [sme_deps_qt5_linux.tgz](https://github.com/spatial-model-editor/sme_deps_qt5/releases/latest/download/sme_deps_qt5_linux.tgz)
+- linux (gcc 9 / Ubuntu 18.04): [sme_deps_qt5_linux.tgz](https://github.com/spatial-model-editor/sme_deps_qt5/releases/latest/download/sme_deps_qt5_linux.tgz)
 - osx (Apple clang 12 / macOS 10.15): [sme_deps_qt5_osx.tgz](https://github.com/spatial-model-editor/sme_deps_qt5/releases/latest/download/sme_deps_qt5_osx.tgz)
 - win32 (mingw-w64-i686-gcc 10): [sme_deps_qt5_win32.tgz](https://github.com/spatial-model-editor/sme_deps_qt5/releases/latest/download/sme_deps_qt5_win32.tgz)
 - win64 (mingw-w64-x86_64-gcc 10): [sme_deps_qt5_win64.tgz](https://github.com/spatial-model-editor/sme_deps_qt5/releases/latest/download/sme_deps_qt5_win64.tgz)

--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,6 @@ echo "OS=$OS"
 echo "PATH=$PATH"
 which g++
 g++ --version
-which make
-make --version
-
 # make qt dir
 mkdir qt
 cd qt
@@ -25,14 +22,13 @@ git checkout $QT5_VERSION
 git submodule update --init qtbase
 cd ..
 
-# make build dir in qt/build and run configure
+# make build dir in qt/build and run cmake
 mkdir build
 cd build
-../qt5/qtbase/configure -opensource -confirm-license ${CONFIGURE_EXTRAS} -prefix ${INSTALL_PREFIX} -release -static -silent -sql-sqlite -qt-zlib -qt-libjpeg -qt-libpng -qt-pcre -qt-harfbuzz -no-compile-examples -nomake tests -nomake examples -no-opengl -no-openssl -no-sql-odbc -no-icu -no-feature-concurrent -no-feature-xml -feature-testlib
-cat config.log
+cmake ../qt5/qtbase -G "Ninja" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DQT_USE_BUNDLED_BundledFreetype=ON -DQT_USE_BUNDLED_BundledHarfbuzz=ON -DQT_USE_BUNDLED_BundledLibpng=ON -DQT_USE_BUNDLED_BundledPcre2=ON -DFEATURE_system_doubleconversion=OFF -DFEATURE_system_freetype=OFF -DFEATURE_system_harfbuzz=OFF -DFEATURE_system_jpeg=OFF -DFEATURE_system_libb2=OFF -DFEATURE_system_pcre2=OFF -DFEATURE_system_png=OFF -DFEATURE_system_proxies=OFF -DFEATURE_system_sqlite=OFF -DFEATURE_system_textmarkdownreader=OFF -DFEATURE_system_zlib=OFF -DFEATURE_zstd=OFF -DFEATURE_openssl=OFF -DFEATURE_sql=OFF -DFEATURE_icu=OFF -DFEATURE_testlib=ON -DBUILD_WITH_PCH=OFF ${CONFIGURE_EXTRAS}
 
-time make -j2
-$SUDO_CMD make install
+time ninja
+$SUDO_CMD ninja install
 
 cd ../..
 


### PR DESCRIPTION
- cmake/ninja instead of configure/make to build
- linux build
  - has to use ubuntu 18.04 due to minimum libxcb version requirement
  - depends on more `libxcb.*-dev` system libs